### PR TITLE
Update parsimonious to 0.10.0 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hypertag-lang
-version = 1.2.0
+version = 1.2.1
 author = Marcin Wojnarski
 author_email = hypertag@paperity.org
 description = Modern language for markup generation with Python-like concise syntax, custom tags & Django integration. HTML templates reinvented.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,11 @@ keywords = markup, language, html, html5, css, templates, templating, tags, jinj
 package_dir =
     = src
 packages = find:
-python_requires = >=3.5
+python_requires = >=3.11
 setup_requires =
     wheel
 install_requires =
-    parsimonious==0.8.1
+    parsimonious>=0.10.0
     six>=1.12.0
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hypertag-lang
-version = 1.2.1
+version = 1.2.2
 author = Marcin Wojnarski
 author_email = hypertag@paperity.org
 description = Modern language for markup generation with Python-like concise syntax, custom tags & Django integration. HTML templates reinvented.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ keywords = markup, language, html, html5, css, templates, templating, tags, jinj
 package_dir =
     = src
 packages = find:
-python_requires = >=3.11
+python_requires = >=3.12
 setup_requires =
     wheel
 install_requires =

--- a/src/hypertag/core/grammar.py
+++ b/src/hypertag/core/grammar.py
@@ -35,7 +35,7 @@ try_short        =  '?' ws (block_struct / body_control)?       # short version 
 block_expr       =  mark_eval expr_assign
 block_assign     =  mark_eval ws targets ws op_inplace? '=' expr_assign
 expr_assign      =  ws (expr_augment / embedding) inline_comment?
-op_inplace       =  ~"//|\%%|<<|>>|[-+*/&|^]"
+op_inplace       =  ~"//|\\%%|<<|>>|[-+*/&|^]"
 
 block_while      =  'while' clause_if clause_else?
 block_for        =  'for' space targets space 'in' space tail_for clause_else?
@@ -61,7 +61,7 @@ attr_def         =  name_id (ws '=' ws value_of_attr)?
 
 block_context    =  'context' space cntx_import (comma cntx_import)* inline_comment?
 block_import     =  'from' space path_import space 'import' space item_import (comma item_import)* inline_comment?
-path_import      =  ~"[^\s\x22\x27]+"                           # import path can be ANY string of 1+ characters unless it contains a whitespace, ' or "
+path_import      =  ~"[^\\s\x22\x27]+"                           # import path can be ANY string of 1+ characters unless it contains a whitespace, ' or "
 item_import      =  wild_import / name_import
 wild_import      =  '*'
 cntx_import      =  symbol rename?
@@ -231,7 +231,7 @@ trailer_filt =  index / member                  # reduced form of `trailer` for 
 partial_call =  '(' ws (args ws)? ')'
 filter       =  factor_filt partial_call?       # no space is allowed between the function and its arguments
 
-qualifier    =  ~"[\?!]"                        # ? means that None/empty(false)/exceptions shall be converted to '' ... ! means that empty (false) value triggers exception
+qualifier    =  ~"[\\?!]"                        # ? means that None/empty(false)/exceptions shall be converted to '' ... ! means that empty (false) value triggers exception
 # obligatory   =  '!'
 # optional     =  '?'
 
@@ -246,7 +246,7 @@ op_shift     =  '<<' / '>>'
 op_empty     =  '?' / '!'
 
 not          =  'not'
-op_comp      =  ~"==|!=|<>|>=|<=|<|>|not\s+in|is\s+not|in|is"
+op_comp      =  ~"==|!=|<>|>=|<=|<|>|not\\s+in|is\\s+not|in|is"
 
 ###  IDENTIFIERS
 
@@ -264,7 +264,7 @@ name_xml         =  ~"[%(XML_StartChar)s]([%(XML_Char)s]*[%(XML_EndChar)s])?"i
 literal          =  number / string / boolean / none
 
 number_signed    =  ~"[+-]?" number
-number           =  ~"((\.\d+)|(\d+(\.\d*)?))([eE][+-]?\d+)?"      # the leading +- is added during expression construction (<neg>)
+number           =  ~"((\\.\\d+)|(\\d+(\\.\\d*)?))([eE][+-]?\\d+)?"      # the leading +- is added during expression construction (<neg>)
 #string           =  ~"'[^']*'" / ~'"[^"]*"'         # '...' or "..." string; no escaping of ' and " inside!
 boolean          =  'True' / 'False'
 none             =  'None'
@@ -279,7 +279,7 @@ string_quot2     =  '"' (escape / embedding / text_quot2)* '"'
 
 ###  BASIC TOKENS
 
-escape      =  ~'\$\$|{{|}}'                 # escape sequences: $$ {{ }}
+escape      =  ~'\\$\\$|{{|}}'                 # escape sequences: $$ {{ }}
 
 verbatim    =  ~"[^%(INDENT_S)s%(DEDENT_S)s%(INDENT_T)s%(DEDENT_T)s\n]+"su       # 1 line of plain text, may include special symbols (left unparsed)
 text        =  ~"[^%(INDENT_S)s%(DEDENT_S)s%(INDENT_T)s%(DEDENT_T)s\n${}]+"su    # 1 line of plain text, excluded $ { }
@@ -332,4 +332,3 @@ def IS_TAG(symbol):
 
 def IS_VAR(symbol):
     return symbol.startswith(MARK_VAR)
-

--- a/src/hypertag/core/xml_chars.py
+++ b/src/hypertag/core/xml_chars.py
@@ -13,8 +13,7 @@
 XML_StartChar  =  r"_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\U00010000-\U000EFFFF"
 
 # human-readable:  XML_StartChar | [0-9.\u00B7-] | [\u0300-\u036F] | [\u203F-\u2040]
-XML_Char       =  XML_StartChar + r"0-9\.\-" + r"\u00B7\u0300-\u036F\u203F-\u2040" + ":"
+XML_Char       =  XML_StartChar + r"0-9\\.\\-" + r"\u00B7\u0300-\u036F\u203F-\u2040" + ":"
 
 # XML_EndChar is like XML_Char, but ":" is NOT allowed, to avoid collision with a trailing ":" used in Hypertag blocks
 XML_EndChar    =  XML_Char[:-1]
-


### PR DESCRIPTION
hypertag 1.2.0 does not work anymore with recent Python versions.

`getargspec` from [parsimonious](https://pypi.org/project/parsimonious/) 0.8.1 is now raising errors:
```
ImportError: cannot import name 'getargspec' from 'inspect'
```
(It should be replaced with `getfullargspec`)

Upgrading to parsimonious 0.10.0 fixes it.